### PR TITLE
Switch to lexicographic sorting of releases

### DIFF
--- a/collections/ansible_collections/kn6plv/aredn/plugins/lookup/firmware.py
+++ b/collections/ansible_collections/kn6plv/aredn/plugins/lookup/firmware.py
@@ -69,7 +69,12 @@ class LookupModule(LookupBase):
                             releases.append(m.group(1))
                     if len(releases) == 0:
                         raise AnsibleError("no releases")
-                    releases.sort(key=LooseVersion)
+
+                    # 2025-0311 Bob Iannucci
+                    # Use lexicographic sorting so that releases[-1] (release) and releases[0] (nightly) will be correct
+                    # releases.sort(key=LooseVersion)
+                    releases.sort()
+
                     if version == "release":
                         version = releases[-1]
                     elif version == "nightly":


### PR DESCRIPTION
LooseVersion causes the sort-order of 'releases' list to put the nightly at the end of the list and the most recent release as second-from-end-of-list.  The rest of the code expects nightly to be at the beginning of the list (releases[0]) and the latest release to be at the end of the list (releases[-1]).

This change eliminates LooseVersion as the sort key in favor of default lexicographic sort, resulting in the expected positions of nightly and latest release.
